### PR TITLE
Update tests to make use of pytest fixtures

### DIFF
--- a/src/sdrun/crystals.py
+++ b/src/sdrun/crystals.py
@@ -173,7 +173,7 @@ class CubicSphere(Crystal):
     def __init__(self):
         super().__init__()
         self.a = 2.
-        self.cell_dimensions = 3
+        self.dimensions = 3
         self.molecule = Sphere()
 
     def get_unitcell(self):
@@ -186,7 +186,7 @@ class SquareCircle(Crystal):
     def __init__(self):
         super().__init__()
         self.a = 2.
-        self.cell_dimensions = 2
+        self.dimensions = 2
         self.molecule = Disc()
 
     def get_unitcell(self):

--- a/src/sdrun/molecules.py
+++ b/src/sdrun/molecules.py
@@ -303,9 +303,8 @@ class Binary_Mixture(Molecule):
         return np.arange(num_molecules * self.num_particles)
 
 
-MOLECULE_LIST = [
-    Trimer(),
-    Dimer(),
-    Binary_Mixture(),
-    Disc(),
-]
+MOLECULE_DICT = {
+    'trimer': Trimer, 'dimer': Dimer, 'binary_mixture': Binary_Mixture, 'disc': Disc
+}
+
+MOLECULE_LIST = [Trimer(), Dimer(), Binary_Mixture(), Disc()]

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -107,8 +107,18 @@ class SimulationParams(object):
     @property
     def cell_dimensions(self) -> Tuple[int, int]:
         try:
-            self.crystal
-            return self.parameters.get('cell_dimensions')
+            cell_dims = self.parameters.get('cell_dimensions')
+            if self.crystal.dimensions == len(cell_dims):
+                return cell_dims
+
+            elif len(cell_dims) == 1:
+                return tuple(list(cell_dims) * self.crystal.dimensions)
+
+            elif len(cell_dims) < self.crystal.dimensions:
+                return tuple(list(cell_dims + [1]))
+
+            else:
+                return tuple(list(cell_dims)[:self.crystal.dimensions])
 
         except AttributeError:
             raise AttributeError

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -108,17 +108,17 @@ class SimulationParams(object):
     def cell_dimensions(self) -> Tuple[int, int]:
         try:
             cell_dims = self.parameters.get('cell_dimensions')
-            if self.crystal.dimensions == len(cell_dims):
+            if self.molecule.dimensions == len(cell_dims):
                 return cell_dims
 
             elif len(cell_dims) == 1:
-                return tuple(list(cell_dims) * self.crystal.dimensions)
+                return tuple(list(cell_dims) * self.molecule.dimensions)
 
-            elif len(cell_dims) < self.crystal.dimensions:
-                return tuple(list(cell_dims + [1]))
+            elif len(cell_dims) < self.molecule.dimensions:
+                return tuple(list(cell_dims) + [1])
 
             else:
-                return tuple(list(cell_dims)[:self.crystal.dimensions])
+                return tuple(list(cell_dims)[:self.molecule.dimensions])
 
         except AttributeError:
             raise AttributeError

--- a/test/crystal_test.py
+++ b/test/crystal_test.py
@@ -8,15 +8,12 @@
 """Testing the crystal class of sdrun."""
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import hoomd
 import numpy as np
 import pytest
-from hypothesis import given, settings
-from hypothesis.extra.numpy import arrays
-from hypothesis.strategies import floats, integers, tuples
-
-from sdrun import crystals, initialise
+from sdrun import crystals
 from sdrun.helper import SimulationParams
 
 TEST_CLASSES = [
@@ -28,88 +25,52 @@ TEST_CLASSES = [
     crystals.SquareCircle,
     crystals.CubicSphere,
 ]
-output_dir = Path('test/output')
-output_dir.mkdir(exist_ok=True)
-PARAMETERS = SimulationParams(
-    temperature=0.4,
-    num_steps=100,
-    outfile_path=output_dir,
-    crystal=crystals.TrimerPg(),
-    cell_dimensions=(32, 40),
-)
 
 
-@pytest.mark.parametrize("crys_class", TEST_CLASSES)
+@pytest.fixture(params=TEST_CLASSES)
+def crys_class(request):
+    return request.param()
+
+
+@pytest.fixture(params=TEST_CLASSES)
+def sim_params(request):
+    with TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir) / 'output'
+        output_dir.mkdir(exist_ok=True)
+        yield SimulationParams(
+            temperature=0.4,
+            num_steps=100,
+            outfile_path=output_dir,
+            crystal=request.param(),
+            cell_dimensions=(32, 40),
+        )
+
+
 def test_init(crys_class):
-    """Check the class will initialise."""
-    crys_class()
+    """Check the initialisation of the class."""
+    assert isinstance(crys_class, crystals.Crystal)
 
 
-@pytest.mark.parametrize("crys_class", TEST_CLASSES)
 def test_get_orientations(crys_class):
-    """Test the orientation is returned as a float."""
-    crys = crys_class()
-    orient = crys.get_orientations()
+    """Test the orientation is returned as quaternions."""
+    orient = crys_class.get_orientations()
     assert orient.dtype == np.float32
+    # Output is in quaternions
+    assert orient.shape[1] == 4
+    # Quaterninons as normalised
+    assert np.allclose(np.linalg.norm(orient, axis=1), 1)
 
 
-@pytest.mark.parametrize("crys_class", TEST_CLASSES)
 def test_get_unitcell(crys_class):
     """Test the return type is correct."""
-    crys = crys_class()
-    assert isinstance(crys.get_unitcell(), hoomd.lattice.unitcell)
+    assert isinstance(crys_class.get_unitcell(), hoomd.lattice.unitcell)
 
 
-@pytest.mark.parametrize("crys_class", TEST_CLASSES)
 def test_compute_volume(crys_class):
     """Test the return type of the volume computation."""
-    crys = crys_class()
-    assert isinstance(crys.compute_volume(), float)
+    assert isinstance(crys_class.compute_volume(), float)
 
 
-@pytest.mark.parametrize("crys_class", TEST_CLASSES)
 def test_abs_positions(crys_class):
     """Check the absolute positions function return corectly shaped matrix."""
-    crys = crys_class()
-    assert crys.get_abs_positions().shape == np.array(crys.positions).shape
-
-
-def get_distance(pos_a, pos_b, box):
-    """Compute the periodic distance between two numpy arrays."""
-    ortho_box = np.array((box.Lx, box.Ly, box.Lz))
-    delta_x = pos_b - pos_a
-    delta_x -= ortho_box * (delta_x > ortho_box * 0.5)
-    delta_x += ortho_box * (delta_x <= -ortho_box * 0.5)
-    return np.sqrt(np.square(delta_x).sum(axis=1))
-
-
-class mybox(object):
-    """Simple box class."""
-
-    def __init__(self):
-        """init."""
-        self.Lx = 1.
-        self.Ly = 1.
-        self.Lz = 1.
-
-
-@given(
-    arrays(np.float, 3, elements=floats(min_value=-1, max_value=1)),
-    arrays(np.float, 3, elements=floats(min_value=-1, max_value=1)),
-)
-def test_get_distance(pos_a, pos_b):
-    """Test the periodic distance function."""
-    box = mybox()
-    diff = get_distance(np.array([pos_a]), np.array([pos_b]), box)
-    print(diff, diff - np.sqrt(2))
-    assert get_distance(np.array([pos_a]), np.array([pos_b]), box) <= np.sqrt(3)
-
-
-@given(tuples(integers(max_value=30, min_value=1), integers(max_value=30, min_value=1)))
-@settings(max_examples=3, deadline=None)
-def test_cell_dimensions(cell_dimensions):
-    """Test cell paramters work properly."""
-    snap = initialise.init_from_crystal(PARAMETERS)
-    for i in snap.particles.position:
-        distances = get_distance(i, snap.particles.position, snap.box) < 1.1
-        assert np.sum(distances) <= 3
+    assert crys_class.get_abs_positions().shape == np.array(crys_class.positions).shape

--- a/test/equilibrate_test.py
+++ b/test/equilibrate_test.py
@@ -8,34 +8,39 @@
 """Test the equilibrate module."""
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
-from sdrun.crystals import TrimerPg
 from sdrun import equilibrate, initialise, params
-
-SIM_PARAMS = params.SimulationParams(
-    temperature=0.4,
-    num_steps=100,
-    crystal=TrimerPg(),
-    outfile_path=Path('test/tmp'),
-    cell_dimensions=(10, 10),
-    outfile=Path('test/tmp/out.gsd'),
-)
+from sdrun.crystals import TrimerPg
 
 
-def init_frame():
-    return initialise.init_from_crystal(SIM_PARAMS)
+@pytest.fixture
+def sim_params():
+    with TemporaryDirectory() as tmp_dir:
+        return params.SimulationParams(
+            temperature=0.4,
+            num_steps=100,
+            crystal=TrimerPg(),
+            outfile_path=tmp_dir,
+            cell_dimensions=(10, 10),
+            outfile=Path(tmp_dir) / 'out.gsd',
+        )
 
 
-def test_equil_crystal():
-    equilibrate.equil_crystal(init_frame(), SIM_PARAMS)
+def init_frame(sim_params):
+    return initialise.init_from_crystal(sim_params)
+
+
+def test_equil_crystal(sim_params):
+    equilibrate.equil_crystal(init_frame(), sim_params)
     assert True
 
 
-def test_equil_interface():
-    equilibrate.equil_interface(init_frame(), SIM_PARAMS)
+def test_equil_interface(sim_params):
+    equilibrate.equil_interface(init_frame(), sim_params)
     assert True
 
 
-def test_equil_liquid():
-    equilibrate.equil_liquid(init_frame(), SIM_PARAMS)
+def test_equil_liquid(sim_params):
+    equilibrate.equil_liquid(init_frame(), sim_params)
     assert True

--- a/test/equilibrate_test.py
+++ b/test/equilibrate_test.py
@@ -10,37 +10,36 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from sdrun import equilibrate, initialise, params
-from sdrun.crystals import TrimerPg
+import pytest
+from sdrun.crystals import CRYSTAL_FUNCS
+from sdrun.equilibrate import equil_crystal, equil_interface, equil_liquid
+from sdrun.initialise import init_from_crystal
+from sdrun.params import SimulationParams
 
 
-@pytest.fixture
-def sim_params():
+@pytest.fixture(params=CRYSTAL_FUNCS.values(), ids=CRYSTAL_FUNCS.keys())
+def sim_params(request):
     with TemporaryDirectory() as tmp_dir:
-        return params.SimulationParams(
+        yield SimulationParams(
             temperature=0.4,
             num_steps=100,
-            crystal=TrimerPg(),
-            outfile_path=tmp_dir,
-            cell_dimensions=(10, 10),
+            crystal=request.param(),
+            output=Path(tmp_dir),
+            cell_dimensions=(10, 12),
             outfile=Path(tmp_dir) / 'out.gsd',
         )
 
 
-def init_frame(sim_params):
-    return initialise.init_from_crystal(sim_params)
-
-
 def test_equil_crystal(sim_params):
-    equilibrate.equil_crystal(init_frame(), sim_params)
+    equil_crystal(init_from_crystal(sim_params), sim_params)
     assert True
 
 
 def test_equil_interface(sim_params):
-    equilibrate.equil_interface(init_frame(), sim_params)
+    equil_interface(init_from_crystal(sim_params), sim_params)
     assert True
 
 
 def test_equil_liquid(sim_params):
-    equilibrate.equil_liquid(init_frame(), sim_params)
+    equil_liquid(init_from_crystal(sim_params), sim_params)
     assert True

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 from hypothesis import example, given, settings
 from hypothesis.strategies import text
-from sdrun.crystals import TrimerP2
+from sdrun.crystals import CubicSphere, TrimerP2
 from sdrun.molecules import Dimer, Disc, Molecule, Sphere, Trimer
 from sdrun.params import SimulationParams, paramsContext
 
@@ -85,3 +85,16 @@ def test_function_passing(sim_params):
         assert sim_params.num_steps == 2000
     assert func(sim_params, 'num_steps') == 1000
     assert sim_params.num_steps == 1000
+
+
+@pytest.mark.parametrize('sim_params', [SIM_PARAMS])
+def test_cell_dimensions(sim_params):
+    with paramsContext(sim_params, crystal=TrimerP2(), cell_dimensions=[10]):
+        assert len(sim_params.cell_dimensions) == sim_params.crystal.dimensions
+        assert sim_params.cell_dimensions == (10, 10)
+    with paramsContext(sim_params, crystal=CubicSphere(), cell_dimensions=[10]):
+        assert len(sim_params.cell_dimensions) == sim_params.crystal.dimensions
+        assert sim_params.cell_dimensions == (10, 10, 10)
+    with paramsContext(sim_params, crystal=CubicSphere(), cell_dimensions=[10, 10]):
+        assert len(sim_params.cell_dimensions) == sim_params.crystal.dimensions
+        assert sim_params.cell_dimensions == (10, 10, 1)

--- a/test/sdrun_test.py
+++ b/test/sdrun_test.py
@@ -8,12 +8,24 @@
 
 """Test the sdrun command line tools."""
 
+import logging
 import subprocess
 import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
-
 from sdrun.main import parse_args
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture
+def output_directory():
+    with TemporaryDirectory() as tmp_dst:
+        yield tmp_dst
+
 
 TEST_ARGS = [
     ['prod', 'test/data/Trimer-13.50-3.00.gsd', '-t', '3.00', '--no-dynamics'],
@@ -26,40 +38,63 @@ TEST_ARGS = [
         '--lattice-lengths',
         '20',
         '24',
-        'test/output/test_create.gsd',
+        'test_create.gsd',
     ],
-    [
-        'equil',
-        '-t',
-        '2.50',
-        'test/data/Trimer-13.50-3.00.gsd',
-        'test/output/test_equil.gsd',
-    ],
+    ['equil', '-t', '2.50', 'test/data/Trimer-13.50-3.00.gsd', 'test_equil.gsd'],
 ]
 
-COMMON_ARGS = ['--hoomd-args', '"--mode=cpu"', '-o', 'test/output', '-s', '100', '-v']
+COMMON_ARGS = ['--hoomd-args', '"--mode=cpu"', '-s', '100', '-v']
 
 
 @pytest.mark.parametrize('arguments', TEST_ARGS)
-def test_man(arguments):
-    func, sim_params = parse_args(arguments + COMMON_ARGS)
+def test_manually(arguments, output_directory):
+    """Testing the functionality of the argument parsing.
+
+    This test replicates the operations of the main() function in a more manual fashion, ensuring
+    the parseing of the arguments works appropriately.
+
+    """
+    logging.debug('output_directory: %s', output_directory)
+    # Use temporary directory for output files
+    if arguments[0] in ['create', 'equil']:
+        arguments[-1] = str(Path(output_directory) / arguments[-1])
+    func, sim_params = parse_args(arguments + COMMON_ARGS + ['-o', output_directory])
     func(sim_params)
 
 
 @pytest.mark.parametrize('arguments', TEST_ARGS)
-def test_commands(arguments):
-    """Ensure sdrun prod works."""
-    subprocess.run(['ls', 'test/data'])
-    command = ['sdrun'] + arguments + COMMON_ARGS
+def test_commands(arguments, output_directory):
+    """Ensure sdrun command line interface works.
+
+    This tests the command line interface is both installed and working correctly, testing each of
+    the main arguments.
+
+    """
+    logging.debug('output_directory: %s', output_directory)
+    # Use temporary directory for output files
+    if arguments[0] in ['create', 'equil']:
+        arguments[-1] = str(Path(output_directory) / arguments[-1])
+    command = ['sdrun'] + arguments + COMMON_ARGS + ['-o', output_directory]
     ret = subprocess.run(command)
     assert ret.returncode == 0
 
 
 @pytest.mark.skipif(sys.platform == 'darwin', reason='No MPI support on macOS')
 @pytest.mark.parametrize('arguments', TEST_ARGS)
-def test_commands_mpi(arguments):
-    """Ensure sdrun prod works."""
-    subprocess.run(['ls', 'test/data'])
-    command = ['mpirun', '-np', '4', 'sdrun'] + arguments + COMMON_ARGS
+def test_commands_mpi(arguments, output_directory):
+    """Ensure sdrun command line interface works with mpi.
+
+    This ensures that running commands with MPI doesn't break things unexpectedly. The test is only
+    run on linux systems since macOS doesn't have simple support for MPI. The tests run here are
+    exactly the same as the test_commands tests, apart from running with mpi.
+
+    """
+    logging.debug('output_directory: %s', output_directory)
+    # Use temporary directory for output files
+    if arguments[0] in ['create', 'equil']:
+        arguments[-1] = str(Path(output_directory) / arguments[-1])
+    command = ['mpirun', '-np', '4', 'sdrun'] + arguments + COMMON_ARGS + [
+        '-o', output_directory
+    ]
     ret = subprocess.run(command)
     assert ret.returncode == 0

--- a/test/simulation_test.py
+++ b/test/simulation_test.py
@@ -7,182 +7,116 @@
 # Distributed under terms of the MIT license.
 """Test the simulation module."""
 
-import gc
-import os
 import subprocess
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import hoomd
 import pytest
-from hypothesis import given, settings
-from hypothesis.strategies import integers, tuples
-
-from sdrun import crystals, molecules
-from sdrun import equilibrate, initialise, simrun
+from sdrun.crystals import CRYSTAL_FUNCS
+from sdrun.equilibrate import equil_crystal
+from sdrun.initialise import init_from_crystal, init_from_none
+from sdrun.molecules import MOLECULE_DICT
 from sdrun.params import SimulationParams, paramsContext
+from sdrun.simrun import run_npt
 
-OUTDIR = Path('test/tmp')
-OUTDIR.mkdir(exist_ok=True)
 HOOMD_ARGS = "--mode=cpu"
-PARAMETERS = SimulationParams(
-    temperature=0.4,
-    num_steps=100,
-    crystal=crystals.TrimerPg(),
-    outfile_path=OUTDIR,
-    outfile=OUTDIR / 'testout',
-    dynamics=False,
-    hoomd_args=HOOMD_ARGS,
-    minimize=True,
-)
+
+
+@pytest.fixture(params=MOLECULE_DICT.values(), ids=MOLECULE_DICT.keys())
+def sim_params(request):
+    with TemporaryDirectory() as tmp_dir:
+        yield SimulationParams(
+            temperature=0.4,
+            num_steps=100,
+            molecule=request.param(),
+            output=tmp_dir,
+            outfile=Path(tmp_dir) / 'testout',
+            dynamics=False,
+            hoomd_args=HOOMD_ARGS,
+            minimize=True,
+        )
+
+
+@pytest.fixture(params=CRYSTAL_FUNCS.values(), ids=CRYSTAL_FUNCS.keys())
+def sim_params_crystal(request):
+    with TemporaryDirectory() as tmp_dir:
+        yield SimulationParams(
+            temperature=0.4,
+            num_steps=100,
+            crystal=request.param(),
+            output=tmp_dir,
+            outfile=Path(tmp_dir) / 'testout',
+            dynamics=False,
+            hoomd_args=HOOMD_ARGS,
+            minimize=True,
+        )
 
 
 @pytest.mark.simulation
-@pytest.mark.parametrize('molecule', molecules.MOLECULE_LIST)
-def test_run_npt(molecule):
+def test_run_npt(sim_params):
     """Test an npt run."""
-    with paramsContext(PARAMETERS, molecule=molecule):
-        snapshot = initialise.init_from_none(PARAMETERS)
-        simrun.run_npt(
-            snapshot=snapshot,
-            context=hoomd.context.initialize(''),
-            sim_params=PARAMETERS,
-        )
-        assert True
+    run_npt(
+        snapshot=init_from_none(sim_params),
+        context=hoomd.context.initialize(HOOMD_ARGS),
+        sim_params=sim_params,
+    )
 
 
-@given(integers(max_value=10, min_value=1))
-@settings(max_examples=5, deadline=None)
-@pytest.mark.hypothesis
-def test_run_multiple_concurrent(max_initial):
-    """Test running multiple concurrent."""
-    with paramsContext(PARAMETERS, max_initial=max_initial):
-        snapshot = initialise.init_from_file(
-            Path('test/data/Trimer-13.50-3.00.gsd'),
-            PARAMETERS.molecule,
-            hoomd_args=PARAMETERS.hoomd_args,
-        )
-        simrun.run_npt(
-            snapshot, context=hoomd.context.initialize(''), sim_params=PARAMETERS
-        )
-    assert True
-    gc.collect()
-
-
-@pytest.mark.parametrize('molecule', molecules.MOLECULE_LIST)
-def test_thermo(molecule):
-    """Test the _set_thermo function works.
-
-    There are many thermodynamic values set in the function and ensuring that
-    they can all be initialised is crucial to a successful simulation.
-    """
-    output = Path('test/tmp')
-    output.mkdir(exist_ok=True)
-    with paramsContext(PARAMETERS, molecule=molecule):
-        snapshot = initialise.init_from_none(PARAMETERS)
-        simrun.run_npt(
-            snapshot, context=hoomd.context.initialize(''), sim_params=PARAMETERS
-        )
-        assert True
-
-
-@given(tuples(integers(max_value=30, min_value=5), integers(max_value=5, min_value=1)))
-@settings(max_examples=10, deadline=None)
-def test_orthorhombic_sims(cell_dimensions):
+@pytest.mark.simulation
+@pytest.mark.parametrize('cell_dimensions', range(1, 5))
+def test_orthorhombic_sims(cell_dimensions, sim_params_crystal):
     """Test the initialisation from a crystal unit cell.
 
     This also ensures there is no unusual things going on with the calculation
     of the orthorhombic unit cell.
     """
-    cell_dimensions = cell_dimensions[0], cell_dimensions[1] * 6
-    output = Path('test/tmp')
-    output.mkdir(exist_ok=True)
-    with paramsContext(PARAMETERS, cell_dimensions=cell_dimensions):
-        snap = initialise.init_from_crystal(PARAMETERS)
-    snap = equilibrate.equil_crystal(snap, sim_params=PARAMETERS)
-    simrun.run_npt(snap, context=hoomd.context.initialize(''), sim_params=PARAMETERS)
-    assert True
-    gc.collect()
+    sim_params = sim_params_crystal
+    cell_dimensions = cell_dimensions * 6, cell_dimensions * 6
+    with paramsContext(sim_params, cell_dimensions=cell_dimensions):
+        snap = init_from_crystal(sim_params)
+    snap = equil_crystal(snap, sim_params=sim_params)
+    run_npt(snap, context=hoomd.context.initialize(HOOMD_ARGS), sim_params=sim_params)
 
 
-@pytest.mark.parametrize('molecule', molecules.MOLECULE_LIST)
-@pytest.mark.xfail
-def test_equil_file_placement(molecule):
-    outdir = Path('test/output')
-    outfile = outdir / 'test_equil'
-    current = list(Path.cwd().glob('*'))
-    for i in outdir.glob('*'):
-        os.remove(str(i))
-    with paramsContext(
-        PARAMETERS,
-        outfile_path=outdir,
-        outfile=outfile,
-        temperature=4.00,
-        molecule=molecule,
-    ):
-        snapshot = initialise.init_from_none(PARAMETERS)
-        equilibrate.equil_liquid(snapshot, PARAMETERS)
-        assert current == list(Path.cwd().glob('*'))
-        assert Path(outfile).is_file()
-    for i in outdir.glob('*'):
-        os.remove(str(i))
-
-
-@pytest.mark.parametrize('molecule', molecules.MOLECULE_LIST)
-@pytest.mark.xfail
-def test_file_placement(molecule):
+@pytest.mark.simulation
+def test_file_placement(sim_params):
     """Ensure files are located in the correct directory when created."""
-    outdir = Path('test/output')
-    current = list(Path.cwd().glob('*'))
-    for i in outdir.glob('*'):
-        os.remove(str(i))
-    with paramsContext(
-        PARAMETERS,
-        outfile_path=outdir,
-        dynamics=True,
-        temperature=3.00,
-        molecule=molecule,
-    ):
-        snapshot = initialise.init_from_none(PARAMETERS)
-        simrun.run_npt(snapshot, hoomd.context.initialize(''), sim_params=PARAMETERS)
-        assert current == list(Path.cwd().glob('*'))
-        sim_params = {
-            'molecule': PARAMETERS.molecule,
-            'pressure': PARAMETERS.pressure,
-            'temperature': PARAMETERS.temperature,
-        }
-        assert (
-            outdir /
-            '{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(**sim_params)
-        ).is_file(
+    with paramsContext(sim_params, dynamics=True):
+        run_npt(
+            init_from_none(sim_params),
+            hoomd.context.initialize(HOOMD_ARGS),
+            sim_params=sim_params,
         )
-        assert (
-            outdir /
-            'dump-{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(
-                **sim_params
-            )
-        ).is_file(
-        )
-        assert (
-            outdir /
-            'thermo-{molecule}-P{pressure:.2f}-T{temperature:.2f}.log'.format(
-                **sim_params
-            )
-        ).is_file(
-        )
-        assert (
-            outdir /
-            'trajectory-{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(
-                **sim_params
-            )
-        ).is_file(
-        )
-    for i in outdir.glob('*'):
-        os.remove(str(i))
+    params = {
+        'molecule': sim_params.molecule,
+        'pressure': sim_params.pressure,
+        'temperature': sim_params.temperature,
+    }
+    outdir = Path(sim_params.output)
+    print(list(outdir.glob('*')))
+    assert (
+        outdir / '{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(**params)
+    ).is_file()
+    assert (
+        outdir /
+        'dump-{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(**params)
+    ).is_file()
+    assert (
+        outdir /
+        'thermo-{molecule}-P{pressure:.2f}-T{temperature:.2f}.log'.format(**params)
+    ).is_file()
+    assert (
+        outdir /
+        'trajectory-{molecule}-P{pressure:.2f}-T{temperature:.2f}.gsd'.format(**params)
+    ).is_file()
 
 
+@pytest.mark.simulation
 @pytest.mark.parametrize('pressure, temperature', [(1.0, 1.8), (13.5, 3.00)])
-def test_interface(pressure, temperature):
+def test_interface(sim_params, pressure, temperature):
     init_temp = 0.4
+    outdir = str(sim_params.output)
     create_command = [
         'sdrun',
         'create',
@@ -198,12 +132,13 @@ def test_interface(pressure, temperature):
         '--steps',
         '1000',
         '--output',
-        OUTDIR,
+        outdir,
         '-vvv',
         '--hoomd-args',
         '"--mode=cpu"',
         str(
-            OUTDIR / 'create_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, init_temp)
+            Path(outdir) /
+            'create_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, init_temp)
         ),
     ]
     melt_command = [
@@ -218,17 +153,19 @@ def test_interface(pressure, temperature):
         '--temperature',
         '{}'.format(temperature),
         '--output',
-        OUTDIR,
+        outdir,
         '--steps',
         '1000',
         '-vvv',
         '--hoomd-args',
         '"--mode=cpu"',
         str(
-            OUTDIR / 'create_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, init_temp)
+            Path(outdir) /
+            'create_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, init_temp)
         ),
         str(
-            OUTDIR / 'melt_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, temperature)
+            Path(outdir) /
+            'melt_interface-P{:.2f}-T{:.2f}.gsd'.format(pressure, temperature)
         ),
     ]
     create = subprocess.run(create_command)

--- a/test/stepsize_test.py
+++ b/test/stepsize_test.py
@@ -9,7 +9,7 @@
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.strategies import integers
 from sdrun.StepSize import GenerateStepSeries, generate_steps
 
@@ -51,7 +51,6 @@ def steps(request):
 
 
 @given(integers(min_value=0))
-@settings(deadline=None)
 def test_initial_start(initial):
     """Ensure the first value produced is the initial value."""
     gen = generate_steps(total_steps=initial + 10, start=initial)
@@ -59,7 +58,6 @@ def test_initial_start(initial):
 
 
 @given(integers(min_value=0))
-@settings(deadline=None)
 def test_initial_start_series(initial):
     """Ensure the first value produced is the initial value."""
     gen = GenerateStepSeries(total_steps=initial + 10)
@@ -80,7 +78,7 @@ def test_final_total_series(final):
     assert genlist[-1] == final
 
 
-def test_generate_steps(steps):  # pylint: disable=redefined-outer-name
+def test_generate_steps(steps):
     """Test generation of steps."""
     assert steps['gen'][-1] == steps['max']
     assert steps['gen'] == steps['def']
@@ -102,11 +100,11 @@ def test_generate_step_series(total_steps, num_linear):
     assert single == series
 
 
-@given(integers(min_value=1, max_value=300))
+@pytest.mark.parametrize('num_linear', [100, 200, 1000, 10, 1])
 def test_num_linear(num_linear):
     """Test a range of values of num_linear will work."""
     gen_list = list(generate_steps(total_steps=1e7, num_linear=num_linear))
-    assert gen_list[: num_linear + 1] == list(range(num_linear + 1))
+    assert gen_list[:num_linear + 1] == list(range(num_linear + 1))
 
 
 def test_get_index():


### PR DESCRIPTION
This is a significant cleanup of all the tests, with a focus on fixing #3 so there weren't a bunch of files placed across the filesystem when testing, instead letting python take care of it with the TemoraryDirectory class.

This implementation uses the TemoraryDirectory context manager inside the fixture using the yield keyword to pass processing onto the requisite function before handling the removal of the temorary directory.