### PR TITLE
Add ability to randomise momenta of simulations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,12 @@ name: sdrun-dev
 channels:
     - defaults
     - conda-forge
-    - glotzer
     - malramsay
 
 dependencies:
     - python=3.6
     - numpy
-    - hoomd=2.3.1
+    - glotzer::hoomd=2.3.1
     - hoomd-harmonic-force=0.1.7
     - cudatoolkit=8
     - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
     - python=3.6
     - numpy
-    - hoomd
+    - hoomd=2.3.1
     - hoomd-harmonic-force=0.1.7
     - cudatoolkit=8
     - pytest

--- a/src/sdrun/initialise.py
+++ b/src/sdrun/initialise.py
@@ -18,7 +18,7 @@ import hoomd
 import hoomd.md
 import numpy as np
 
-from .util import get_num_mols, get_num_particles
+from .util import get_num_mols, get_num_particles, randomise_momenta
 from .molecules import Molecule
 from .params import SimulationParams
 
@@ -116,6 +116,13 @@ def initialise_snapshot(
 
     if minimize:
         snapshot = minimize_snapshot(snapshot, sim_params, ensemble="NVE")
+
+    if sim_params.iteration_id is not None:
+        interface = False
+        # Interface simulations require the space_group paramter to be set
+        if sim_params.space_group is not None:
+            interface = True
+        snapshot = randomise_momenta(snapshot, interface)
 
     with context:
         sys = hoomd.init.read_snapshot(snapshot)

--- a/src/sdrun/initialise.py
+++ b/src/sdrun/initialise.py
@@ -18,9 +18,9 @@ import hoomd
 import hoomd.md
 import numpy as np
 
-from .util import get_num_mols, get_num_particles, randomise_momenta
 from .molecules import Molecule
 from .params import SimulationParams
+from .util import get_num_mols, get_num_particles, randomise_momenta
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,9 @@ def initialise_snapshot(
         # Interface simulations require the space_group paramter to be set
         if sim_params.space_group is not None:
             interface = True
-        snapshot = randomise_momenta(snapshot, interface)
+        snapshot = randomise_momenta(
+            snapshot, interface, random_seed=sim_params.iteration_id
+        )
 
     with context:
         sys = hoomd.init.read_snapshot(snapshot)

--- a/src/sdrun/main.py
+++ b/src/sdrun/main.py
@@ -18,7 +18,7 @@ from .crystals import CRYSTAL_FUNCS
 from .initialise import init_from_crystal, init_from_file, init_from_none
 from .molecules import Dimer, Disc, Sphere, Trimer
 from .params import SimulationParams
-from .simulation import production, create_interface, equilibrate
+from .simulation import create_interface, equilibrate, production
 from .version import __version__
 
 logger = logging.getLogger(__name__)
@@ -77,6 +77,9 @@ def _verbosity(ctx, param, value) -> None:
     "--harmonic-force",
     type=float,
     help="Harmonic force constant for simulations with harmonic pinning potentials.",
+)
+@click.option(
+    "--iteration-id", type=int, help="Identifier for isoconfigurational simulation run."
 )
 @click.option(
     "--space-group",

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -67,7 +67,7 @@ class SimulationParams(object):
     def temperature(self) -> Union[float, hoomd.variant.linear_interp]:
         """Temperature of the system."""
         assert self._temperature is not None
-        assert self._temperature > 0
+        assert self._temperature >= 0
 
         if self.init_temp is None:
             return self._temperature
@@ -90,7 +90,7 @@ class SimulationParams(object):
     @temperature.setter
     def temperature(self, value: float) -> None:
         assert value is not None
-        assert value > 0, f"Temperature cannot be negative. You gave: {value}"
+        assert value >= 0, f"Temperature cannot be negative. You gave: {value}"
         self._temperature = float(value)
 
     @property
@@ -216,6 +216,7 @@ class SimulationParams(object):
             mom_inertia=self.moment_inertia_scale,
             space_group=self.space_group,
             harmonic_force=self.harmonic_force,
+            iteration_id=self.iteration_id,
         )
         return self.output / fname
 

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -61,6 +61,7 @@ class SimulationParams(object):
     )
 
     hoomd_args: str = attr.ib(default="", repr=False)
+    iteration_id: int = None
 
     @property
     def temperature(self) -> Union[float, hoomd.variant.linear_interp]:
@@ -196,6 +197,9 @@ class SimulationParams(object):
         space_group = None
         if self.space_group is not None:
             base_string += "-{space_group}"
+
+        if self.iteration_id is not None:
+            base_string += "-ID{iteration_id}"
 
         logger.debug("filename base string: %s", base_string)
         logger.debug("Temperature: %.2f", self._temperature)

--- a/src/sdrun/util.py
+++ b/src/sdrun/util.py
@@ -168,10 +168,13 @@ def set_harmonic_force(
 
 
 def randomise_momenta(
-    snapshot: SnapshotParticleData, interface: bool = False
+    snapshot: SnapshotParticleData, interface: bool = False, random_seed=None
 ) -> SnapshotParticleData:
     """Randomise the momenta of particles in a snapshot."""
     num_mols = get_num_mols(snapshot)
+
+    if random_seed is not None:
+        np.random.RandomState(seed=random_seed)
 
     if interface:
         velocity_dist = snapshot.particles.velocity[:num_mols]

--- a/src/sdrun/util.py
+++ b/src/sdrun/util.py
@@ -167,9 +167,34 @@ def set_harmonic_force(
     )
 
 
-def randomise_momenta(snapshot: SnapshotParticleData) -> SnapshotParticleData:
+def randomise_momenta(
+    snapshot: SnapshotParticleData, interface: bool = False
+) -> SnapshotParticleData:
     """Randomise the momenta of particles in a snapshot."""
     num_mols = get_num_mols(snapshot)
+
+    if interface:
+        velocity_dist = snapshot.particles.velocity[:num_mols]
+        velocity_dist = velocity_dist[np.linalg.norm(velocity_dist, axis=1) > 1e-5]
+        # Flatten array to choose from distribution of all values
+        #  velocity_dist = velocity_dist.flatten()
+        assert velocity_dist.shape[0] > 0
+
+        angmom_dist = snapshot.particles.angmom[:num_mols]
+        # Only choose values that are non-zero
+        angmom_dist = angmom_dist[np.linalg.norm(angmom_dist, axis=1) > 0]
+        assert angmom_dist.shape[0] > 0
+
+        for i in range(num_mols):
+            snapshot.particles.velocity[i] = velocity_dist[
+                np.random.choice(velocity_dist.shape[0], 1)
+            ]
+            snapshot.particles.angmom[i] = angmom_dist[
+                np.random.choice(angmom_dist.shape[0], 1)
+            ]
+
+        return snapshot
+
     np.random.shuffle(snapshot.particles.velocity[:num_mols])
     np.random.shuffle(snapshot.particles.angmom[:num_mols])
     return snapshot

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -8,8 +8,8 @@
 """Test the SimulationParams class."""
 
 import logging
-from pathlib import Path
 from itertools import product
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -193,6 +193,7 @@ def filename_params():
         "moment_inertia_scale",
         "harmonic_force",
         "space_group",
+        "iteration_id",
     ]
     space_groups = ["p2", "p2gg", "pg"]
     molecules = [Trimer()]
@@ -209,6 +210,8 @@ def filename_params():
                 params["space_group"] = space_group
             elif param in ["temperature", "pressure"]:
                 params[param] = value2
+            elif param in ["iteration_id"]:
+                params[param] = int(value1) if value1 is not None else None
             else:
                 params[param] = value1
         yield params
@@ -220,6 +223,7 @@ def get_filename_prefix(key):
         "pressure": "P",
         "moment_inertia_scale": "I",
         "harmonic_force": "K",
+        "iteration_id": "ID",
     }
     return prefixes.get(key, "")
 
@@ -235,6 +239,9 @@ def test_filename(sim_params, params):
             assert isinstance(prefix, str)
             logger.debug("Prefix: %s, Value: %s", prefix, value)
             if isinstance(value, (int, float)):
-                assert f"{prefix}{value:.2f}" in fname
+                if key == "iteration_id":
+                    assert f"{prefix}{value:d}" in fname
+                else:
+                    assert f"{prefix}{value:.2f}" in fname
             else:
                 assert f"{prefix}{value}" in fname

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -9,11 +9,18 @@
 """Test the util module."""
 
 import hoomd
+import numpy as np
 import pytest
 from hoomd.data import boxdim, make_snapshot
 
 # TODO set_integrator, set_debug, set_dump, dump_frame, set_thermo, set_harmonic_force
-from sdrun.util import NumBodies, _get_num_bodies, get_num_mols, get_num_particles
+from sdrun.util import (
+    NumBodies,
+    _get_num_bodies,
+    get_num_mols,
+    get_num_particles,
+    randomise_momenta,
+)
 
 
 @pytest.fixture
@@ -42,3 +49,41 @@ def test_get_num_particles(create_snapshot):
 def test_get_num_mols(create_snapshot):
     num_bodies = get_num_mols(create_snapshot["snapshot"])
     assert num_bodies == create_snapshot["num_bodies"].molecules
+
+
+@pytest.fixture(params=["Interface", "No-Interface"])
+def snapshot(request):
+    snap_file = "test/data/Trimer-13.50-3.00.gsd"
+    if request.param == "Interface":
+        snapshot = hoomd.data.gsd_snapshot(snap_file)
+        num_mols = get_num_mols(snapshot)
+        stationary_particles = int(num_mols / 3)
+        snapshot.particles.velocity[:stationary_particles] = np.zeros(
+            (stationary_particles, 3), dtype=np.float32
+        )
+        snapshot.particles.angmom[:stationary_particles] = np.zeros(
+            (stationary_particles, 4), dtype=np.float32
+        )
+        return snapshot
+    return hoomd.data.gsd_snapshot("test/data/Trimer-13.50-3.00.gsd")
+
+
+@pytest.mark.parametrize("interface", [False, True])
+def test_randomise_momenta(snapshot, interface):
+    snap = randomise_momenta(snapshot, interface)
+    num_mols = get_num_mols(snapshot)
+    angmom_similarity = np.sum(
+        snap.particles.angmom[:num_mols] != snapshot.particles.angmom[:num_mols]
+    )
+    velocity_similarity = np.sum(
+        snap.particles.velocity[:num_mols] != snapshot.particles.velocity[:num_mols]
+    )
+    assert angmom_similarity < 5
+    assert velocity_similarity < 5
+    if interface:
+        assert np.any(snap.particles.velocity[:num_mols] > 0)
+        assert np.any(snap.particles.angmom[:num_mols] > 0)
+        velocity_norm = np.linalg.norm(snap.particles.velocity[:num_mols], axis=1)
+        assert np.sum(velocity_norm == 0) < 5
+        angmom_norm = np.linalg.norm(snap.particles.angmom[:num_mols], axis=1)
+        assert np.sum(angmom_norm == 0) < 5

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -87,3 +87,25 @@ def test_randomise_momenta(snapshot, interface):
         assert np.sum(velocity_norm == 0) < 5
         angmom_norm = np.linalg.norm(snap.particles.angmom[:num_mols], axis=1)
         assert np.sum(angmom_norm == 0) < 5
+
+
+@pytest.mark.parametrize("seed", [0, 1, 10])
+def test_randomise_seed_same(snapshot, seed):
+    snap1 = randomise_momenta(snapshot, random_seed=seed)
+    snap2 = randomise_momenta(snapshot, random_seed=seed)
+    assert np.all(snap1.particles.velocity == snap2.particles.velocity)
+    assert np.all(snap1.particles.angmom == snap2.particles.angmom)
+
+
+def test_randomise_seed_different(snapshot):
+    num_mols = get_num_mols(snapshot)
+    snap1 = randomise_momenta(snapshot, random_seed=0)
+    snap2 = randomise_momenta(snapshot, random_seed=1)
+    angmom_similarity = np.sum(
+        snap1.particles.angmom[:num_mols] != snap2.particles.angmom[:num_mols]
+    )
+    velocity_similarity = np.sum(
+        snap1.particles.velocity[:num_mols] != snap2.particles.velocity[:num_mols]
+    )
+    assert angmom_similarity < 5
+    assert velocity_similarity < 5


### PR DESCRIPTION
There is a technique known as isoconfigurational ensembles which uses the same positions of
particles, however randomises the momenta. This gives an idea of how the structure of the simulation
affects the resulting properties. This adds support for running isoconfigurational ensembles using
the iteration_id variable. Simulations with the same starting configuration and iteration_id will be
the same, as the iteration_id sets the random seed for the randomisation step.