### PR TITLE
Extract group from SimulationParams class

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - hypothesis
     - coverage
     - ipykernel
-    - black=18.5b0
+    - black=18.6b2
     - mypy
     - attrs
     - click
@@ -25,4 +25,3 @@ dependencies:
         - pytest-mypy
         - pytest-pylint
         - pytest-cov
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,3 @@ include_trailing_comma = True
 force_grid_wrap = 0
 combine_as_imports = True
 line_length = 88
-

--- a/src/sdrun/initialise.py
+++ b/src/sdrun/initialise.py
@@ -236,7 +236,6 @@ def make_orthorhombic(
     snapshot.particles.position[:, 0] += xlen / 2.
     snapshot.particles.position[:, 0] %= len_x
     snapshot.particles.position[:, 0] -= len_x / 2.
-    logger.debug("Updated positions: \n%s", snapshot.particles.position)
     box = hoomd.data.boxdim(len_x, len_y, len_z, 0, 0, 0, dimensions=dimensions)
     hoomd.data.set_snapshot_box(snapshot, box)
     return snapshot

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -30,7 +30,7 @@ class SimulationParams(object):
     pressure: float = 13.5
     tauP: float = attr.ib(default=1.0, repr=False)
     init_temp: Optional[float] = None
-    _group: Optional[hoomd.group.group] = None
+    group: Optional[hoomd.group.group] = None
 
     # Molecule params
     _molecule: Optional[Molecule] = None
@@ -141,21 +141,6 @@ class SimulationParams(object):
         self._cell_dimensions = value
 
     @property
-    def group(self) -> hoomd.group.group:
-        """Return the appropriate group."""
-        if self._group:
-            return self._group
-
-        if self.molecule.num_particles == 1:
-            return hoomd.group.all()
-
-        return hoomd.group.rigid_center()
-
-    @group.setter
-    def group(self, value: hoomd.group.group) -> None:
-        self._group = value
-
-    @property
     def infile(self) -> Path:
         return self._infile
 
@@ -219,6 +204,13 @@ class SimulationParams(object):
             iteration_id=self.iteration_id,
         )
         return self.output / fname
+
+    def get_group(self) -> hoomd.group.group:
+        if self.group is None:
+            if self.molecule.num_particles > 1:
+                return hoomd.group.rigid_center()
+            return hoomd.group.all()
+        return self.group
 
     @contextmanager
     def temp_context(self, **kwargs):

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -31,7 +31,6 @@ class SimulationParams(object):
     pressure: float = 13.5
     tauP: float = attr.ib(default=1.0, repr=False)
     init_temp: Optional[float] = None
-    group: Optional[hoomd.group.group] = None
 
     # Molecule params
     _molecule: Optional[Molecule] = None
@@ -205,13 +204,6 @@ class SimulationParams(object):
             iteration_id=self.iteration_id,
         )
         return self.output / fname
-
-    def get_group(self) -> hoomd.group.group:
-        if self.group is None:
-            if self.molecule.num_particles > 1:
-                return hoomd.group.rigid_center()
-            return hoomd.group.all()
-        return self.group
 
     @contextmanager
     def temp_context(self, **kwargs):

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 @attr.s(auto_attribs=True)
 class SimulationParams(object):
     """Store the parameters of the simulation."""
+
     # Thermodynamic Params
     _temperature: float = 0.4
     tau: float = attr.ib(default=1.0, repr=False)

--- a/src/sdrun/simulation.py
+++ b/src/sdrun/simulation.py
@@ -16,10 +16,10 @@ import hoomd.md
 import numpy as np
 from hoomd.data import SnapshotParticleData
 
-from .util import dump_frame, set_dump, set_harmonic_force, set_integrator, set_thermo
 from .initialise import init_from_crystal, initialise_snapshot, make_orthorhombic
 from .params import SimulationParams
 from .StepSize import GenerateStepSeries
+from .util import dump_frame, set_dump, set_harmonic_force, set_integrator, set_thermo
 
 logger = logging.getLogger(__name__)
 

--- a/src/sdrun/simulation.py
+++ b/src/sdrun/simulation.py
@@ -203,13 +203,15 @@ def production(
         sys = initialise_snapshot(snapshot, context, sim_params)
         logger.debug("Run metadata: %s", sys.get_metadata())
 
+        group = get_group(sys, sim_params)
+
         if simulation_type == "harmonic":
             set_integrator(
-                sim_params, simulation_type="crystal", integration_method="NVT"
+                sim_params, group, simulation_type="crystal", integration_method="NVT"
             )
-            set_harmonic_force(snapshot, sim_params)
+            set_harmonic_force(snapshot, sim_params, group)
         else:
-            set_integrator(sim_params, simulation_type="liquid")
+            set_integrator(sim_params, group, simulation_type="liquid")
 
         set_thermo(
             sim_params.filename(prefix="thermo"),

--- a/src/sdrun/util.py
+++ b/src/sdrun/util.py
@@ -54,7 +54,7 @@ def set_integrator(
 
     if integration_method == "NPT":
         integrator = md.integrate.npt(
-            group=sim_params.group,
+            group=sim_params.get_group(),
             kT=sim_params.temperature,
             tau=sim_params.tau,
             P=sim_params.pressure,
@@ -70,7 +70,7 @@ def set_integrator(
 
     elif integration_method == "NVT":
         integrator = md.integrate.nvt(
-            group=sim_params.group, kT=sim_params.temperature, tau=sim_params.tau
+            group=sim_params.get_group(), kT=sim_params.temperature, tau=sim_params.tau
         )
 
     return integrator
@@ -160,7 +160,7 @@ def set_harmonic_force(
         return
     num_mols = get_num_mols(snapshot)
     HarmonicForceCompute(
-        sim_params.group,
+        sim_params.get_group(),
         snapshot.particles.position[:num_mols],
         snapshot.particles.orientation[:num_mols],
         sim_params.harmonic_force,

--- a/src/sdrun/util.py
+++ b/src/sdrun/util.py
@@ -146,7 +146,7 @@ def set_thermo(outfile: Path, thermo_period: int = 10000, rigid=True) -> None:
 
 
 def set_harmonic_force(
-    snapshot: SnapshotParticleData, sim_params: SimulationParams, group
+    snapshot: SnapshotParticleData, sim_params: SimulationParams, group: Group
 ) -> None:
     from hoomd.harmonic_force import HarmonicForceCompute
 
@@ -155,7 +155,7 @@ def set_harmonic_force(
         return
     num_mols = get_num_mols(snapshot)
     HarmonicForceCompute(
-        sim_params.get_group(),
+        group,
         snapshot.particles.position[:num_mols],
         snapshot.particles.orientation[:num_mols],
         sim_params.harmonic_force,

--- a/test/argparse_test.py
+++ b/test/argparse_test.py
@@ -63,7 +63,6 @@ def dummy_subcommand(obj):
 
 @pytest.fixture(params=["create", "equil", "prod"])
 def subcommands(request):
-
     class Subcommand(NamedTuple):
         command: Callable
         params: List

--- a/test/equilibrate_test.py
+++ b/test/equilibrate_test.py
@@ -14,9 +14,9 @@ import numpy as np
 import pytest
 
 from sdrun.crystals import CRYSTAL_FUNCS
-from sdrun.simulation import create_interface, equilibrate
 from sdrun.initialise import init_from_crystal, make_orthorhombic
 from sdrun.params import SimulationParams
+from sdrun.simulation import create_interface, equilibrate
 
 
 @pytest.fixture(params=CRYSTAL_FUNCS.values(), ids=CRYSTAL_FUNCS.keys())

--- a/test/equilibrate_test.py
+++ b/test/equilibrate_test.py
@@ -29,6 +29,7 @@ def sim_params(request):
             output=Path(tmp_dir),
             cell_dimensions=(10, 12, 10),
             outfile=Path(tmp_dir) / "out.gsd",
+            hoomd_args="--mode=cpu --notice-level=0",
         )
 
 

--- a/test/equilibrate_test.py
+++ b/test/equilibrate_test.py
@@ -10,13 +10,15 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import hoomd
 import numpy as np
 import pytest
 
 from sdrun.crystals import CRYSTAL_FUNCS
 from sdrun.initialise import init_from_crystal, make_orthorhombic
+from sdrun.molecules import MOLECULE_DICT
 from sdrun.params import SimulationParams
-from sdrun.simulation import create_interface, equilibrate
+from sdrun.simulation import create_interface, equilibrate, get_group
 
 
 @pytest.fixture(params=CRYSTAL_FUNCS.values(), ids=CRYSTAL_FUNCS.keys())
@@ -26,6 +28,20 @@ def sim_params(request):
             temperature=0.4,
             num_steps=1000,
             crystal=request.param(),
+            output=Path(tmp_dir),
+            cell_dimensions=(10, 12, 10),
+            outfile=Path(tmp_dir) / "out.gsd",
+            hoomd_args="--mode=cpu --notice-level=0",
+        )
+
+
+@pytest.fixture(params=MOLECULE_DICT.values(), ids=MOLECULE_DICT.keys())
+def mol_params(request):
+    with TemporaryDirectory() as tmp_dir:
+        yield SimulationParams(
+            temperature=0.4,
+            num_steps=1000,
+            molecule=request.param(),
             output=Path(tmp_dir),
             cell_dimensions=(10, 12, 10),
             outfile=Path(tmp_dir) / "out.gsd",
@@ -78,3 +94,10 @@ def test_equilibrate(sim_params, equil_type):
         assert snapshot.box.xy == 0
         assert snapshot.box.xz == 0
         assert snapshot.box.yz == 0
+
+
+def test_get_group(mol_params):
+    with hoomd.context.initialize(mol_params.hoomd_args):
+        sys = hoomd.init.create_lattice(hoomd.lattice.sq(1), 5)
+        group = get_group(sys, mol_params)
+        assert group is not None

--- a/test/harmonic_test.py
+++ b/test/harmonic_test.py
@@ -17,7 +17,7 @@ import pytest
 from sdrun.crystals import CRYSTAL_FUNCS
 from sdrun.initialise import init_from_crystal, minimize_snapshot
 from sdrun.params import SimulationParams
-from sdrun.simulation import production, equilibrate
+from sdrun.simulation import equilibrate, production
 
 
 @pytest.fixture(params=CRYSTAL_FUNCS.values(), ids=CRYSTAL_FUNCS.keys())

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -12,6 +12,7 @@ from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import hoomd
 import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
@@ -99,6 +100,10 @@ def test_group_setter(sim_params):
     group = "testgroup"
     sim_params.group = group
     assert sim_params.group == group
+
+
+def get_group_default(sim_params):
+    assert sim_params.group is None
 
 
 def test_mol_crys(sim_params):
@@ -245,3 +250,10 @@ def test_filename(sim_params, params):
                     assert f"{prefix}{value:.2f}" in fname
             else:
                 assert f"{prefix}{value}" in fname
+
+
+def test_get_group(mol_params):
+    with hoomd.context.initialize(mol_params.hoomd_args):
+        hoomd.init.create_lattice(hoomd.lattice.sq(1), 1)
+        group = mol_params.get_group()
+        assert group is not None

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -235,7 +235,6 @@ def get_filename_prefix(key):
 
 @pytest.mark.parametrize("params", filename_params())
 def test_filename(sim_params, params):
-
     with sim_params.temp_context(**params):
         fname = sim_params.filename().stem
     for key, value in params.items():

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -12,7 +12,6 @@ from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import hoomd
 import pytest
 from hypothesis import given
 from hypothesis.strategies import floats
@@ -89,16 +88,6 @@ def test_cell_dimensions_setter(sim_params, cell_len):
         assert sim_params.cell_dimensions == cell_dims
     else:
         assert sim_params.cell_dimensions == (*cell_dims[:2], 1)
-
-
-def test_group_setter(sim_params):
-    group = "testgroup"
-    sim_params.group = group
-    assert sim_params.group == group
-
-
-def get_group_default(sim_params):
-    assert sim_params.group is None
 
 
 def test_mol_crys(sim_params):
@@ -244,10 +233,3 @@ def test_filename(sim_params, params):
                     assert f"{prefix}{value:.2f}" in fname
             else:
                 assert f"{prefix}{value}" in fname
-
-
-def test_get_group(mol_params):
-    with hoomd.context.initialize(mol_params.hoomd_args):
-        hoomd.init.create_lattice(hoomd.lattice.sq(1), 1)
-        group = mol_params.get_group()
-        assert group is not None

--- a/test/params_test.py
+++ b/test/params_test.py
@@ -33,11 +33,6 @@ def sim_params():
 
 
 @pytest.fixture(params=MOLECULE_DICT.values(), ids=MOLECULE_DICT.keys())
-def mol_params(request):
-    return SimulationParams(num_steps=1000, temperature=1.0, molecule=request.param)
-
-
-@pytest.fixture(params=MOLECULE_DICT.values(), ids=MOLECULE_DICT.keys())
 def molecules(request):
     return request.param
 

--- a/test/simulation_test.py
+++ b/test/simulation_test.py
@@ -30,7 +30,7 @@ def sim_params(request):
             molecule=request.param(),
             output=tmp_dir,
             outfile=Path(tmp_dir) / "testout",
-            hoomd_args="--mode=cpu",
+            hoomd_args="--mode=cpu --notice-level=0",
         )
 
 
@@ -43,7 +43,7 @@ def sim_params_crystal(request):
             crystal=request.param(),
             output=tmp_dir,
             outfile=Path(tmp_dir) / "testout",
-            hoomd_args="--mode=cpu",
+            hoomd_args="--mode=cpu --notice-level=0",
         )
 
 
@@ -129,7 +129,7 @@ def test_interface(sim_params, pressure, temperature):
         outdir,
         "-vvv",
         "--hoomd-args",
-        '"--mode=cpu"',
+        '"--mode=cpu --notice-level=0"',
         "create",
         str(Path(outdir) / "P{:.2f}-T{:.2f}.gsd".format(pressure, init_temp)),
     ]
@@ -147,7 +147,7 @@ def test_interface(sim_params, pressure, temperature):
         "1000",
         "-vvv",
         "--hoomd-args",
-        '"--mode=cpu"',
+        '"--mode=cpu --notice-level=0"',
         "equil",
         "--equil-type",
         "interface",

--- a/test/simulation_test.py
+++ b/test/simulation_test.py
@@ -18,7 +18,7 @@ from sdrun.crystals import CRYSTAL_FUNCS
 from sdrun.initialise import init_from_crystal, init_from_none
 from sdrun.molecules import MOLECULE_DICT
 from sdrun.params import SimulationParams
-from sdrun.simulation import production, equilibrate, make_orthorhombic
+from sdrun.simulation import equilibrate, make_orthorhombic, production
 
 
 @pytest.fixture(params=MOLECULE_DICT.values(), ids=MOLECULE_DICT.keys())

--- a/test/simulation_test.py
+++ b/test/simulation_test.py
@@ -129,7 +129,7 @@ def test_interface(sim_params, pressure, temperature):
         outdir,
         "-vvv",
         "--hoomd-args",
-        '"--mode=cpu --notice-level=0"',
+        '"--mode=cpu"',
         "create",
         str(Path(outdir) / "P{:.2f}-T{:.2f}.gsd".format(pressure, init_temp)),
     ]
@@ -147,7 +147,7 @@ def test_interface(sim_params, pressure, temperature):
         "1000",
         "-vvv",
         "--hoomd-args",
-        '"--mode=cpu --notice-level=0"',
+        '"--mode=cpu"',
         "equil",
         "--equil-type",
         "interface",


### PR DESCRIPTION
A Hoomd group is undefined unless a hoomd simulation has been initialised.
Having one of the class attributes only accessible after a simulation has
been initialised is somewhat problematic. I have made it more apparent that
there is something unusual going on by moving the logic from the group
parameter to the get_group() function.