### PR TITLE
STY Use sensible class names for hoomd classes

### DIFF
--- a/src/sdrun/initialise.py
+++ b/src/sdrun/initialise.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import hoomd
 import hoomd.md
 import numpy as np
+from hoomd.context import SimulationContext as Context
+from hoomd.data import SnapshotParticleData as Snapshot, system_data as System
 
 from .molecules import Molecule
 from .params import SimulationParams
@@ -25,9 +27,7 @@ from .util import get_num_mols, get_num_particles, randomise_momenta
 logger = logging.getLogger(__name__)
 
 
-def init_from_file(
-    fname: Path, molecule: Molecule, hoomd_args: str = ""
-) -> hoomd.data.SnapshotParticleData:
+def init_from_file(fname: Path, molecule: Molecule, hoomd_args: str = "") -> Snapshot:
     """Initialise a hoomd simulation from an input file."""
     logger.debug("Initialising from file %s", fname)
     # Hoomd context needs to be initialised before calling gsd_snapshot
@@ -44,7 +44,7 @@ def init_from_file(
     return init_snapshot
 
 
-def init_from_none(sim_params: SimulationParams) -> hoomd.data.SnapshotParticleData:
+def init_from_none(sim_params: SimulationParams) -> Snapshot:
     """Initialise a system from no inputs.
 
     This creates a simulation with a large unit cell lattice such that there
@@ -92,11 +92,11 @@ def init_from_none(sim_params: SimulationParams) -> hoomd.data.SnapshotParticleD
 
 
 def initialise_snapshot(
-    snapshot: hoomd.data.SnapshotParticleData,
-    context: hoomd.context.SimulationContext,
+    snapshot: Snapshot,
+    context: Context,
     sim_params: SimulationParams,
     minimize: bool = False,
-) -> hoomd.data.system_data:
+) -> System:
     """Initialise the configuration from a snapshot.
 
     In this function it is checked that the data in the snapshot and the
@@ -137,10 +137,8 @@ def initialise_snapshot(
 
 
 def minimize_snapshot(
-    snapshot: hoomd.data.SnapshotParticleData,
-    sim_params: SimulationParams,
-    ensemble: str = "NVE",
-) -> hoomd.data.SnapshotParticleData:
+    snapshot: Snapshot, sim_params: SimulationParams, ensemble: str = "NVE"
+) -> Snapshot:
     assert ensemble in ["NVE", "NPH"]
     temp_context = hoomd.context.initialize(sim_params.hoomd_args)
     with temp_context:
@@ -176,7 +174,7 @@ def minimize_snapshot(
     return equil_snapshot
 
 
-def init_from_crystal(sim_params: SimulationParams) -> hoomd.data.SnapshotParticleData:
+def init_from_crystal(sim_params: SimulationParams) -> Snapshot:
     """Initialise a hoomd simulation from a crystal lattice.
 
     Args:
@@ -210,9 +208,7 @@ def init_from_crystal(sim_params: SimulationParams) -> hoomd.data.SnapshotPartic
     return snap
 
 
-def make_orthorhombic(
-    snapshot: hoomd.data.SnapshotParticleData
-) -> hoomd.data.SnapshotParticleData:
+def make_orthorhombic(snapshot: Snapshot) -> Snapshot:
     """Create orthorhombic unit cell from snapshot.
 
     This uses the periodic boundary conditions of the cell to generate an
@@ -241,9 +237,7 @@ def make_orthorhombic(
     return snapshot
 
 
-def _check_properties(
-    snapshot: hoomd.data.SnapshotParticleData, molecule: Molecule
-) -> hoomd.data.SnapshotParticleData:
+def _check_properties(snapshot: Snapshot, molecule: Molecule) -> Snapshot:
     num_molecules = get_num_mols(snapshot)
     num_particles = get_num_particles(snapshot)
 

--- a/src/sdrun/params.py
+++ b/src/sdrun/params.py
@@ -179,7 +179,6 @@ class SimulationParams(object):
         if self.harmonic_force is not None:
             base_string += "-K{harmonic_force:.2f}"
 
-        space_group = None
         if self.space_group is not None:
             base_string += "-{space_group}"
 

--- a/src/sdrun/simulation.py
+++ b/src/sdrun/simulation.py
@@ -14,7 +14,7 @@ import logging
 import hoomd
 import hoomd.md
 import numpy as np
-from hoomd.data import SnapshotParticleData
+from hoomd.data import SnapshotParticleData as Snapshot, system_data as System
 from hoomd.group import group as Group
 
 from .initialise import init_from_crystal, initialise_snapshot, make_orthorhombic
@@ -26,10 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 def equilibrate(
-    snapshot: SnapshotParticleData,
-    sim_params: SimulationParams,
-    equil_type: str = "liquid",
-) -> SnapshotParticleData:
+    snapshot: Snapshot, sim_params: SimulationParams, equil_type: str = "liquid"
+) -> Snapshot:
     """Run an equilibration simulation.
 
     This will configure and run an equilibration simulation of the type specified in equil_type.
@@ -114,7 +112,7 @@ def equilibrate(
     return equil_snapshot
 
 
-def create_interface(sim_params: SimulationParams) -> SnapshotParticleData:
+def create_interface(sim_params: SimulationParams) -> Snapshot:
     """Helper for the creation of a liquid--crystal interface.
 
     The creation of a liquid--crystal interface has a number of different steps. This is a helper
@@ -144,7 +142,7 @@ def create_interface(sim_params: SimulationParams) -> SnapshotParticleData:
 
 
 def get_group(
-    sys: hoomd.data.system_data, sim_params: SimulationParams, interface: bool = False
+    sys: System, sim_params: SimulationParams, interface: bool = False
 ) -> Group:
     if sim_params.molecule.num_particles > 1:
         group = hoomd.group.rigid_center()
@@ -155,9 +153,7 @@ def get_group(
     return group
 
 
-def _interface_group(
-    sys: hoomd.data.system_data, base_group: Group, stationary: bool = False
-):
+def _interface_group(sys: System, base_group: Group, stationary: bool = False):
     assert base_group is not None
     stationary_group = hoomd.group.cuboid(
         name="stationary",
@@ -179,7 +175,7 @@ def _interface_group(
 
 
 def production(
-    snapshot: SnapshotParticleData,
+    snapshot: Snapshot,
     context: hoomd.context.SimulationContext,
     sim_params: SimulationParams,
     dynamics: bool = True,

--- a/src/sdrun/util.py
+++ b/src/sdrun/util.py
@@ -15,7 +15,7 @@ from typing import List, NamedTuple
 import hoomd
 import hoomd.md as md
 import numpy as np
-from hoomd.data import SnapshotParticleData
+from hoomd.data import SnapshotParticleData as Snapshot
 from hoomd.group import group as Group
 
 from .params import SimulationParams
@@ -146,7 +146,7 @@ def set_thermo(outfile: Path, thermo_period: int = 10000, rigid=True) -> None:
 
 
 def set_harmonic_force(
-    snapshot: SnapshotParticleData, sim_params: SimulationParams, group: Group
+    snapshot: Snapshot, sim_params: SimulationParams, group: Group
 ) -> None:
     from hoomd.harmonic_force import HarmonicForceCompute
 
@@ -164,8 +164,8 @@ def set_harmonic_force(
 
 
 def randomise_momenta(
-    snapshot: SnapshotParticleData, interface: bool = False, random_seed=None
-) -> SnapshotParticleData:
+    snapshot: Snapshot, interface: bool = False, random_seed=None
+) -> Snapshot:
     """Randomise the momenta of particles in a snapshot."""
     num_mols = get_num_mols(snapshot)
 
@@ -204,7 +204,7 @@ class NumBodies(NamedTuple):
     molecules: int
 
 
-def _get_num_bodies(snapshot: SnapshotParticleData) -> NumBodies:
+def _get_num_bodies(snapshot: Snapshot) -> NumBodies:
     try:
         num_particles = snapshot.particles.N
         num_mols = max(snapshot.particles.body) + 1
@@ -222,11 +222,11 @@ def _get_num_bodies(snapshot: SnapshotParticleData) -> NumBodies:
     return NumBodies(num_particles, num_mols)
 
 
-def get_num_mols(snapshot: SnapshotParticleData) -> int:
+def get_num_mols(snapshot: Snapshot) -> int:
     num_bodies = _get_num_bodies(snapshot)
     return num_bodies.molecules
 
 
-def get_num_particles(snapshot: SnapshotParticleData) -> int:
+def get_num_particles(snapshot: Snapshot) -> int:
     num_bodies = _get_num_bodies(snapshot)
     return num_bodies.particles


### PR DESCRIPTION
This gives the class names from hoomd more sensible names for brevity
and simplicity.
hoomd.data.SnapshotParticleData -> Snapshot
hoomd.data.system_data -> System
hoomd.context.SimulationContext -> Context